### PR TITLE
Use Fava CSS vars for dark mode compatibility

### DIFF
--- a/src/beancount_plugin_tax_uk/templates/UKTaxPlugin.html
+++ b/src/beancount_plugin_tax_uk/templates/UKTaxPlugin.html
@@ -193,14 +193,16 @@
 select {
     padding: 0.5rem;
     min-width: 150px;
-    border: 1px solid #ddd;
+    border: 1px solid var(--border);
     border-radius: 4px;
     height: 2.5rem;
+    background-color: var(--background);
+    color: var(--text-color);
 }
 
-.button {
+.uk-cgt .button {
     padding: 0 1.5rem !important;
-    background-color: #4CAF50;
+    background-color: var(--button-background);
     border: none;
     border-radius: 4px;
     cursor: pointer;
@@ -213,15 +215,15 @@ select {
     height: 2.5rem;
     line-height: 2.5rem;
     margin-left: auto;
-    color: #ffffff;
+    color: var(--button-color);
 }
 
-.button:visited {
-    color: #ffffff;
+.uk-cgt .button:visited {
+    color: var(--button-color);
 }
 
-.button:hover {
-    background-color: #45a049;
+.uk-cgt .button:hover {
+    opacity: 0.85;
 }
 
 .year-section {
@@ -232,7 +234,7 @@ select {
 .year-section h3 {
     margin-bottom: 2rem;
     padding-bottom: 0.5rem;
-    border-bottom: 2px solid #666;
+    border-bottom: 2px solid var(--border-darker);
 }
 
 .summary-table {
@@ -242,29 +244,29 @@ select {
 .events-section {
     margin-bottom: 3rem;
     padding: 1rem;
-    border: 1px solid #ddd;
+    border: 1px solid var(--border);
     border-radius: 4px;
 }
 
 .events-section h4 {
     margin-top: 0;
     padding-bottom: 0.5rem;
-    border-bottom: 2px solid #eee;
+    border-bottom: 2px solid var(--border-lighter);
 }
 
 .num {
     text-align: right;
-    font-family: monospace;
+    font-family: var(--font-family-monospaced), monospace;
 }
 
 table.table td.gain,
 table.table td.num.gain {
-    color: #3daf46 !important;
+    color: var(--diff-green) !important;
 }
 
 table.table td.loss,
 table.table td.num.loss {
-    color: #af3d3d !important;
+    color: var(--diff-red) !important;
 }
 
 table.table {
@@ -276,12 +278,13 @@ table.table {
 table.table th,
 table.table td {
     padding: 0.5rem;
-    border: 1px solid #ddd;
+    border: 1px solid var(--table-border);
 }
 
 table.table th {
     font-weight: bold;
-    /* background-color: #e0e0e0; */
+    background-color: var(--table-header-background);
+    color: var(--table-header-text);
 }
 
 .total-row {
@@ -289,23 +292,23 @@ table.table th {
 }
 
 .total-row td {
-    border-top: 2px solid #666;
+    border-top: 2px solid var(--border-darker);
 }
 
 a.button:visited {
-    color: #ffffff;
+    color: var(--button-color);
 }
 
 .detailed-rows-section {
     margin-top: 4rem;
     padding-top: 2rem;
-    border-top: 3px solid #666;
+    border-top: 3px solid var(--border-darker);
 }
 
 .detailed-rows-section h2 {
     margin-bottom: 2rem;
     padding-bottom: 0.5rem;
-    border-bottom: 2px solid #666;
+    border-bottom: 2px solid var(--border-darker);
 }
 
 .rows-container {
@@ -321,33 +324,33 @@ a.button:visited {
     white-space: nowrap;
     position: sticky;
     top: 0;
-    background-color: #f5f5f5;
+    background-color: var(--table-header-background);
     z-index: 10;
 }
 
 .year-divider-row {
-    background-color: #add8e6;
+    background-color: light-dark(hsl(195deg 53% 79%), hsl(200deg 30% 25%));
     font-weight: bold;
 }
 
 .year-divider-row td {
     padding: 0.75rem;
-    border-top: 2px solid #666;
-    border-bottom: 2px solid #666;
+    border-top: 2px solid var(--border-darker);
+    border-bottom: 2px solid var(--border-darker);
 }
 
 .asset-divider-row {
-    background-color: #d9ead3;
+    background-color: light-dark(hsl(120deg 39% 85%), hsl(125deg 20% 22%));
     font-weight: bold;
 }
 
 .asset-divider-row td {
     padding: 0.75rem;
-    border-top: 1px solid #999;
+    border-top: 1px solid var(--border-darker);
 }
 
 .sell-row {
-    background-color: #fff2cc !important;
+    background-color: light-dark(hsl(45deg 100% 90%), hsl(45deg 30% 22%)) !important;
 }
 
 </style>


### PR DESCRIPTION
Looks much prettier in dark mode now.

Before:

<img width="1319" height="801" alt="Screenshot 2026-02-14 at 15 09 55" src="https://github.com/user-attachments/assets/39d6a12b-f1f2-4f86-84e4-9e31cefa2a94" />

<img width="1319" height="801" alt="Screenshot 2026-02-14 at 15 10 05" src="https://github.com/user-attachments/assets/12940388-7779-4d42-97fc-2fad004b48ed" />

After:

<img width="1319" height="801" alt="Screenshot 2026-02-14 at 15 08 28" src="https://github.com/user-attachments/assets/db7dfd5b-8ea3-401e-bb87-35ce87d8f27f" />

<img width="1319" height="801" alt="Screenshot 2026-02-14 at 15 08 47" src="https://github.com/user-attachments/assets/955a615d-9414-4d88-9c3b-ac46ae7b8437" />
