### PR TITLE
Fix title to match dropdown

### DIFF
--- a/src/beancount_plugin_tax_uk/templates/UKTaxPlugin.html
+++ b/src/beancount_plugin_tax_uk/templates/UKTaxPlugin.html
@@ -20,7 +20,7 @@
 
         {% for year in report.years %}
         <div class="year-section" id="year-{{ year }}" style="display: none;">
-            <h3>Tax Year {{ year - 1 }}/{{ year }}</h3>
+            <h3>Tax Year {{ year }}/{{ year + 1 }}</h3>
 
             <div class="summary-table">
                 <h4>Summary by Category</h4>
@@ -360,4 +360,4 @@ window.showYear = UKTaxPlugin.showYear;
 document.addEventListener('DOMContentLoaded', () => UKTaxPlugin.initializeTaxView());
 
 </script> -->
-{% endblock %} 
+{% endblock %}


### PR DESCRIPTION
Fixes the page title to match the tax year in the dropdown.

Before:

https://github.com/user-attachments/assets/1727d919-f0a3-451f-801b-494625ec2323


After:


https://github.com/user-attachments/assets/218d3e49-d7c2-4b55-8e91-88765ca481c1

